### PR TITLE
Fix Error handling in parseStudyChunkId

### DIFF
--- a/src/utils/dataLoader.ts
+++ b/src/utils/dataLoader.ts
@@ -116,15 +116,21 @@ export const loadOpenGNTData = async (studyChunks: Record<string, StudyChunk[]>,
 
             const studyChunkID = parseStudyChunkID(studyChunks, greek, morphology);
 
-            mappedData.push({
-              BookChapterVerseWord: bookChapterVerseWord,
-              Greek: greek,
-              Morphology: morphology,
-              English: english,
-              Meaning: rootMeaning,
-              StudyChunkID: studyChunkID,
-              StrongsNumber: strongsNumber
-            });
+            if (!studyChunkID) {
+              console.error("studyChunkID is undefined. Not pushing into datamap")
+            } else {
+              mappedData.push({
+                BookChapterVerseWord: bookChapterVerseWord,
+                Greek: greek,
+                Morphology: morphology,
+                English: english,
+                Meaning: rootMeaning,
+                StudyChunkID: studyChunkID,
+                StrongsNumber: strongsNumber
+              });
+            }
+
+            
 
             if (strongsMapping[strongsNumber]) {
               if (strongsMapping[strongsNumber][morphology]) {

--- a/src/utils/dataLoader.ts
+++ b/src/utils/dataLoader.ts
@@ -377,7 +377,7 @@ const parseStudyChunkID = (studyChunks : Record<string, StudyChunk[]>, greek : s
     }
   }
   // TODO (Caleb) (Paul-check): verify that this should never be possible. this used to return null.
-  throw Error("could not get studyChunkID");
+  console.error("could not get studyChunkID in parseStudyChunkID: ", {studyChunks, greek, morphology});
 }
 
 /*


### PR DESCRIPTION
- Change the error handling from throw error to console.error.
- Handle the undefined type in loadOpenGNTData