### PR TITLE
Fix keyboard shortcuts, cleanup wordcontext and related visuals

### DIFF
--- a/src/atoms/headerAtoms.ts
+++ b/src/atoms/headerAtoms.ts
@@ -3,6 +3,6 @@ import { atom } from 'jotai';
 
 export const chartsOpenAtom = atom<boolean>(false);
 
-export const helpOpenAtom = atom<boolean>(false);
+export const infoOpenAtom = atom<boolean>(false);
 
 export const settingsOpenAtom = atom<boolean>(false);

--- a/src/components/Header/InfoPopup.tsx
+++ b/src/components/Header/InfoPopup.tsx
@@ -4,7 +4,7 @@ import Popup from "../Popup";
 import React, {useContext} from "react";
 import {AppContext} from "../../contexts/AppContext";
 import grey from "@mui/material/colors/grey";
-import { helpOpenAtom } from "../../atoms/headerAtoms";
+import { infoOpenAtom } from "../../atoms/headerAtoms";
 import { useAtom } from "jotai";
 import TableChartIcon from '@mui/icons-material/TableChart';
 import VisibilityIcon from '@mui/icons-material/Visibility';
@@ -12,7 +12,7 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import { useNavigation } from "../useNavigation";
 
 const InfoPopup = () => {
-  const [helpOpen, setHelpOpen] = useAtom(helpOpenAtom);
+  const [infoOpen, setInfoOpen] = useAtom(infoOpenAtom);
   const theme = useTheme();
   const probablyNoKeyboard = useMediaQuery(theme.breakpoints.down('md'));
   const context = useContext(AppContext);
@@ -24,7 +24,7 @@ const InfoPopup = () => {
    testWordIndices, selectedTesters
   } = context;
 
-  return (<Popup open={helpOpen} onClose={() => setHelpOpen(false)} title="Help">
+  return (<Popup open={infoOpen} onClose={() => setInfoOpen(false)} title="Info">
       {/* List the keyboard shortcuts:
          LeftArrow = next word
          RightArrow = previous word
@@ -63,7 +63,13 @@ const InfoPopup = () => {
                   <pre>&gt; next tested word</pre>
                 </li>
                 <li>
-                  <pre>? open this menu (info)</pre>
+                  <pre>e toggle english</pre>
+                </li>
+                <li>
+                  <pre>g grammar tables</pre>
+                </li>
+                <li>
+                  <pre>? (this) info menu</pre>
                 </li>
                 <li>
                   <pre>/ open settings</pre>

--- a/src/components/useHeader.ts
+++ b/src/components/useHeader.ts
@@ -1,10 +1,10 @@
 import { useAtom } from "jotai";
-import { chartsOpenAtom, helpOpenAtom, settingsOpenAtom } from "../atoms/headerAtoms";
+import { chartsOpenAtom, infoOpenAtom, settingsOpenAtom } from "../atoms/headerAtoms";
 
 
 
 export const useHeader = () => {
-    const [, setHelpOpen] = useAtom(helpOpenAtom);
+    const [, setHelpOpen] = useAtom(infoOpenAtom);
     const [, setChartsOpen] = useAtom(chartsOpenAtom);
     const [, setSettingsOpen] = useAtom(settingsOpenAtom);
 

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -8,6 +8,7 @@ import { useAtom } from 'jotai';
 import { startTestingAtom } from '../atoms/testingAtoms';
 import { defaultShowAnswerAtom, displayWordsAtom, openGNTDataAtom, readingModeAtom, selectedTestersAtom, showAnswerAtom, testWordIndicesAtom } from '../atoms/bibleDisplayAtoms';
 import { useNavigation } from '../components/useNavigation';
+import { settingsOpenAtom, infoOpenAtom, chartsOpenAtom } from '../atoms/headerAtoms';
 
 
 
@@ -22,7 +23,9 @@ interface AppProviderProps {
 export const AppProvider: React.FC<AppProviderProps>  = ({children}) => {
   const { currentChapter, currentIndex, goLeft, goRight, setCurrentIndexAndProcess} = useNavigation();
 
-
+  const [_, setSettingsOpen] = useAtom(settingsOpenAtom);
+  const [__, setInfoOpen] = useAtom(infoOpenAtom);
+  const [___, setChartsOpen] = useAtom(chartsOpenAtom);
   // const [selectedTesters, setSelectedTesters] = useState<Tester[]>([]);
   const [selectedTesters, setSelectedTesters] = useAtom(selectedTestersAtom);
   const [gotNewData, setGotNewData] = useState(false);
@@ -134,15 +137,33 @@ export const AppProvider: React.FC<AppProviderProps>  = ({children}) => {
       } else if (e.key === '>') {
         nextTestWord();
       } else if (e.key === ' ') {
-        // prevent scrolling on space
-        if (e.target === document.body) {
+        // Prevent default space key behavior if not in an input field
+        if (e.target.tagName !== 'INPUT' && e.target.tagName !== 'TEXTAREA') {
           e.preventDefault();
+          flipCard();
         }
-        flipCard();
       } else if (e.key === '?') {
-        // TODO fix open help
+        // open the info modal
+        setInfoOpen((prev) => !prev);
+        setSettingsOpen(false);
+        setChartsOpen(false);
       } else if (e.key === '/') {
-        // TODO fix open settings
+        // open the settings modal
+        setSettingsOpen((prev) => !prev);
+        setInfoOpen(false);
+        setChartsOpen(false);
+      } else if (e.key.toLowerCase() === 'e') {
+        // toggle "Show English in Context"
+        if (e.target.tagName !== 'INPUT' && e.target.tagName !== 'TEXTAREA') {
+          setShowEnglishInContext(prev => !prev);
+        }
+      } else if (e.key.toLowerCase() === 'g') {
+        // toggle "Show English in Context"
+        if (e.target.tagName !== 'INPUT' && e.target.tagName !== 'TEXTAREA') {
+          setChartsOpen(prev => !prev);
+          setInfoOpen(false);
+          setSettingsOpen(false);
+        }
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
         markWord(currentIndex, true);


### PR DESCRIPTION
## Changes

1. Shortcuts 'e', 'g', '/', and '?' should now work.
2. Word Context now is more visually stable with question marks
3. Word Context now should blank out the correct words based on the settings (previously showed everything even though that was unchecked)
4. Renamed symbols in Header that were confusing

## Testing

1. Make sure that the shortcuts e', 'g', '/', and '?' work.
2. Check out 1 John 1:1 with unit 10 selected. It should look and behave a lot better with various combinations of setting "Show English below Word Context" and "Show Answer on Non-Tested Words" to different values.